### PR TITLE
Change actions to SERV1

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -43,7 +43,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: #${{ matrix.os }} <-- disabled to prefer self-hosted
+      labels: serv1 # <-- remove line to use non self-hosted
 
     steps:
     - name: Checkout Master


### PR DESCRIPTION
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Change github actions to run on SERV1 rather then the slow github servers

## Technical details
Github actions now run on SERV1 (Self-hosted) server