### PR TITLE
Overflow hard limit

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -281,6 +281,8 @@ public sealed partial class LatheMenu : DefaultWindow
             {
                 if (!int.TryParse(AmountLineEdit.Text, out var amount) || amount <= 0)
                     amount = 1;
+                if (amount > 1000)
+                    return; /// Sandwich - Integer overflow prevention, if more then 1000 items are requested, the lathe will refuse to produce them.
                 RecipeQueueAction?.Invoke(s, amount);
             };
             RecipeList.AddChild(control);


### PR DESCRIPTION
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Hard limits the Lathe from printing more then 1000 items at the time

## Technical details
Simple IF <1000 check, then dont do anything

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- Either:
- [ ] I have given credit the right people in the right [attributions.yml (example)](https://github.com/SandwichStation/SandwichStation/blob/master/Resources/Audio/_ShibaStation/Lobby/attributions.yml) file
- [X] I own the rights to the added content
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Cant print more then 1000 per queue order.

**Changelog**
:cl:
- fix: Fixed crash of server on printing 1000+ items at the same time